### PR TITLE
Fix favicon retrieval

### DIFF
--- a/docs/overrides/about.html
+++ b/docs/overrides/about.html
@@ -51,7 +51,7 @@
     <meta charset="utf-8">
     <meta name="viewport" content="width=device-width, initial-scale=1, shrink-to-fit=no">
     <title>UNB Cybersec</title>
-    <link rel="icon" type="image/png" href="images/favicon.png" sizes="16x16">
+    <link rel="icon" type="image/png" href="{{ 'assets/images/favicon.png' | url }}" sizes="16x16">
     <link rel="stylesheet" href="https://use.fontawesome.com/releases/v5.6.3/css/all.css" integrity="sha384-UHRtZLI+pbxtHCWp1t77Bi1L4ZtiqrqD80Kn4Z8NTSRyMA2Fd33n5dQ8lWUE00s/" crossorigin="anonymous">
     
     <link rel="stylesheet" href="{{ 'assets/css/bootstrap4-neon-glow.min.css' | url }}">

--- a/docs/overrides/crypto.html
+++ b/docs/overrides/crypto.html
@@ -5,7 +5,7 @@
     <meta charset="UTF-8">
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
     <title>Spin Me Right Round</title>
-    <link rel="icon" type="image/png" href="images/favicon.png" sizes="16x16">
+    <link rel="icon" type="image/png" href="{{ 'assets/images/favicon.png' | url }}" sizes="16x16">
     <link rel="stylesheet" href="https://use.fontawesome.com/releases/v5.6.3/css/all.css"
         integrity="sha384-UHRtZLI+pbxtHCWp1t77Bi1L4ZtiqrqD80Kn4Z8NTSRyMA2Fd33n5dQ8lWUE00s/" crossorigin="anonymous">
 

--- a/docs/overrides/home.html
+++ b/docs/overrides/home.html
@@ -51,7 +51,7 @@
     <meta charset="utf-8">
     <meta name="viewport" content="width=device-width, initial-scale=1, shrink-to-fit=no">
     <title>UNB Cybersec</title>
-    <link rel="icon" type="image/png" href="images/favicon.png" sizes="16x16">
+    <link rel="icon" type="image/png" href="{{ 'assets/images/favicon.png' | url }}" sizes="16x16">
     <link rel="stylesheet" href="https://use.fontawesome.com/releases/v5.6.3/css/all.css" integrity="sha384-UHRtZLI+pbxtHCWp1t77Bi1L4ZtiqrqD80Kn4Z8NTSRyMA2Fd33n5dQ8lWUE00s/" crossorigin="anonymous">
     
     <link rel="stylesheet" href="{{ 'assets/css/bootstrap4-neon-glow.min.css' | url }}">


### PR DESCRIPTION
The favicon paths in the html overrides are currently hardcoded which creates a relative path that resolves to `/.../images/favicon.png` when on the about/home/etc. page(s), which results in the favicon not loading on them. This fixes that by using the correct path.